### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ACSNetworking是一个依赖于[AFNetworking](https://github.com/AFNetworking/AF
 
 #### 直接导入
 [下载 ACSNetworking](https://github.com/Hyosung/ACSNetworking/archive/master.zip) 然后导入到你的iOS或者OSX项目中，注意你还得[下载 AFNetworking](https://github.com/AFNetworking/AFNetworking/archive/master.zip)
-#### 使用Cocoapods
+#### 使用CocoaPods
 
 **Podfile**
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
